### PR TITLE
Normalize the response code into an integer

### DIFF
--- a/lib/http/exceptions.rb
+++ b/lib/http/exceptions.rb
@@ -29,7 +29,7 @@ module Http
     end
 
     def self.check_response!(res)
-      raise HttpException.new(response: res) unless (200...300).include?(res.code)
+      raise HttpException.new(response: res) unless (200...300).include?(res.code.to_i)
       res
     end
 

--- a/spec/http_exception_spec.rb
+++ b/spec/http_exception_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe Http::Exceptions do
-  let(:invalid_response) { double(code: 400, body: '') }
-  let(:valid_response) { double(code: 200) }
+  let(:code)     { 200 }
+  let(:response) { double(code: code, body: '') }
 
   class TestException < RuntimeError
   end
 
   describe ".wrap_exception" do
-    let(:supported_exception_class) { Http::Exceptions::Configuration::DEFAULT_EXCEPTIONS_TO_CONVERT.first }
+    let(:supported_exception_class)   { Http::Exceptions::Configuration::DEFAULT_EXCEPTIONS_TO_CONVERT.first }
     let(:unsupported_exception_class) { TestException }
 
     context "when exception class is supported" do
@@ -47,30 +47,54 @@ describe Http::Exceptions do
   end
 
   describe ".check_response!" do
-    it "raises exception on non-200 response" do
-      expect do
-        described_class.check_response!(invalid_response)
-      end.to raise_error(Http::Exceptions::HttpException)
-    end
+    shared_examples 'invalid response' do |error_status_code|
+      context "when the response code is not a 200" do
+        let(:code) { error_status_code }
 
-    it "the raised exception contains the response" do
-      begin
-        described_class.check_response!(invalid_response)
-      rescue Http::Exceptions::HttpException => e
-        expect(e.response).to eq(invalid_response)
+        it "raises exception" do
+          expect do
+            described_class.check_response!(response)
+          end.to raise_error(Http::Exceptions::HttpException)
+        end
+      end
+
+      it "the raised exception contains the response" do
+        begin
+          described_class.check_response!(response)
+        rescue Http::Exceptions::HttpException => e
+          expect(e.response).to eq(response)
+        end
       end
     end
 
-    it "returns the response on valid response" do
-      expect(described_class.check_response!(valid_response)).to eq(valid_response)
+    shared_examples 'valid response' do |successful_status_code|
+      context "when the response code is a 200" do
+        let(:code) { successful_status_code }
+
+        it "returns the response" do
+          expect(described_class.check_response!(response)).to eq(response)
+        end
+      end
+    end
+
+    context "when the response code is an integer" do
+      it_behaves_like 'invalid response', 400
+      it_behaves_like 'valid response', 200
+    end
+
+    context "when the response code is a string" do
+      it_behaves_like 'invalid response', '400'
+      it_behaves_like 'valid response', '200'
     end
   end
 
   describe ".wrap_and_check" do
-    it "raises exception on bad response" do
+    let(:code) { 400 }
+
+    it "raises an exception on a response with an error code" do
       expect do
         described_class.wrap_and_check do
-          invalid_response
+          response
         end
       end.to raise_error(Http::Exceptions::HttpException)
     end


### PR DESCRIPTION
The core class Net::HTTP returns its response code as a String.
http://ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTPResponse.html

HTTParty returns its code as an integer.
https://github.com/jnunemaker/httparty/blob/master/lib/httparty/response.rb#L38

This one small change allows this library to be used with the core class and remain
backwards compatible for http-party.

Add some test and refactor duplication into shared_examples