### PR TITLE
bump version to 0.1.2

### DIFF
--- a/lib/http/exceptions/version.rb
+++ b/lib/http/exceptions/version.rb
@@ -1,5 +1,5 @@
 module Http
   module Exceptions
-    VERSION = "0.1.0"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
0.1.1 is conspicuously missing from our git history... let's just fix it moving forward.
  