### PR TITLE
Fix spelling typo in exception message

### DIFF
--- a/lib/http/exceptions/http_exception.rb
+++ b/lib/http/exceptions/http_exception.rb
@@ -6,7 +6,7 @@ module Http
       def initialize(options = {})
         @original_exception = options[:original_exception]
         @response = options[:response]
-        msg = "An error as occured while processing response."
+        msg = "An error as occurred while processing response."
         msg += " Status #{response.code}\n#{response.body}" if response
         msg += " Original Exception: #{original_exception}" if original_exception
         super msg


### PR DESCRIPTION
The correct spelling is "occurred" (not occured).

Per:
https://www.grammarly.com/blog/occurred-occured-ocurred/