### PR TITLE
Set homepage in gemspec

### DIFF
--- a/http-exceptions.gemspec
+++ b/http-exceptions.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["simon.math@gmail.com"]
   spec.summary       = %q{An easy way to rescue exceptions that might be thrown by your Http library}
   spec.description   = %q{An easy way to rescue exceptions that might be thrown by your Http library}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/rainforestapp/http-exceptions"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
It makes it easy to find the source of this gem from [rubygems.org](https://rubygems.org/gems/http-exceptions).
I also expect that the PRs created by dependabot will include information about the updates.