### PR TITLE
Update CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/rainforestapp/http-exceptions.png?branch=master)](https://travis-ci.org/rainforestapp/http-exceptions)
+[![CircleCI](https://circleci.com/gh/rainforestapp/http-exceptions.svg?style=svg)](https://circleci.com/gh/rainforestapp/http-exceptions)
 
 # Http::Exceptions
 


### PR DESCRIPTION
`travis.yml` has already been removed at #26.
This PR replaces the CI status badge from Travis CI to Circle CI.